### PR TITLE
assets: css: site: standardization of images

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -29,6 +29,10 @@ h1 {
   height: 96vh;
 }
 
+.container .img-center {
+  max-width: 100%;
+}
+
 .container a {
   color: #399f62;
   text-decoration: none;


### PR DESCRIPTION
This commit is a solution for incorrect settings of all sizes
in the post images, as well as handling the responsiveness of the images as well.

step-by-step problem: when opening any post with a large image,
the image size breaks the structure of the site horizontally, invading
the space of other elements and a scroll bar is created to navigate through the image.

Signed-off-by: Aquila Macedo <aquila0dayprofissional@gmail.com>