### PR TITLE
assets: css: site: side spacing and text overflow.

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -70,8 +70,17 @@ h1 {
     padding: 10;
   }
 
+  a {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .inner-post p {
+    display: inline-block;
+  }
+
   .container .content {
     font-size: 1.2rem;
+    margin: 0 13px 0 13px;
   }
 
   .container .sidebar {


### PR DESCRIPTION
This commit fixes the text-overflow in the "about" tab
and also adds spacing on the side edges.

Signed-off-by: Aquila Macedo <aquilamacedo@riseup.net>