### PR TITLE
feed: feed separate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,27 @@ About the arguments:
 1. --target: The element with itens in the _layouts. For example, development.html
 2. --name: The name of the new section
 3. --image: The name for the new section
+
+## About Feeds separate.
+
+### How feeds separate work
+
+The separation of feeds is performed to filter and organize the posts.
+
+The *feed.xml* file encompasses all posts without filtering any category, that is, it is the general feed of the site.
+
+The *feed-freedesktop.xml* file filters posts by the "freedesktop" category and creates a feed with only posts that have that category.
+
+
+### How to add a post to freedesktop feed
+
+To add a post to the freedesktop feed, simply include the "freedesktop" category in the front matter of the post.
+
+> Use:
+
+```
+---
+layout: post
+categories: freedesktop
+---
+```

--- a/feed-freedesktop.xml
+++ b/feed-freedesktop.xml
@@ -1,0 +1,25 @@
+---
+layout: none
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <channel>
+    <link href="{{ site.url }}/feed-freedesktop.xml" rel="self" type="application/atom+xml"/>
+    <link href="{{ site.url }}/" rel="alternate" type="text/html"/>
+    <updated>{{ site.time | date_to_xmlschema }}</updated>
+    <id>{{ site.url }}</id>
+    <title type="html">{{ site.title | xml_escape }}</title>
+    <subtitle>{{ site.description | xml_escape }}</subtitle>
+    {% for post in site.categories['freedesktop'] limit:7 %}
+    <entry>
+        <title type="html">{{ post.title | xml_escape }}</title>
+        <link href="{{ post.url | prepend: site.url }}"/>
+        <published>{{ post.date | date_to_xmlschema }}</published>
+        <id isPermaLink="true">{{ post.url | prepend: site.url }}</id>
+        <category>{{ post.categories }}</category>
+        <content type="html">{{ post.content | xml_escape }}</content>
+    </entry>
+    {% endfor %}
+  </channel>
+</feed>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,25 @@
+---
+layout: none
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <channel>
+    <link href="{{ site.url }}/feed.xml" rel="self" type="application/atom+xml"/>
+    <link href="{{ site.url }}/" rel="alternate" type="text/html"/>
+    <updated>{{ site.time | date_to_xmlschema }}</updated>
+    <id>{{ site.url }}</id>
+    <title type="html">{{ site.title | xml_escape }}</title>
+    <subtitle>{{ site.description | xml_escape }}</subtitle>
+    {% for post in site.posts limit:7 %}
+    <entry>
+        <title type="html">{{ post.title | xml_escape }}</title>
+        <link href="{{ post.url | prepend: site.url }}"/>
+        <published>{{ post.date | date_to_xmlschema }}</published>
+        <id isPermaLink="true">{{ post.url | prepend: site.url }}</id>
+        <category>{{ post.categories }}</category>
+        <content type="html">{{ post.content | xml_escape }}</content>
+    </entry>
+    {% endfor %}
+  </channel>
+</feed>


### PR DESCRIPTION
This commit modifies the global feed structure and creates
a new feed filtering the "freedesktop" category.

Signed-off-by: Aquila Macedo <aquilamacedo@riseup.net>